### PR TITLE
Fix fractional scaling for single output

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -8,6 +8,7 @@
 
 bool is_format_supported(enum wl_shm_format fmt);
 uint32_t get_format_min_stride(enum wl_shm_format fmt, uint32_t width);
+pixman_format_code_t get_pixman_format(enum wl_shm_format fmt);
 
 pixman_image_t *render(struct grim_state *state, struct grim_box *geometry,
 	double scale);

--- a/main.c
+++ b/main.c
@@ -673,13 +673,14 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-	size_t n_pending = 0;
-	struct grim_output *output;
-	wl_list_for_each(output, &state.outputs, link) {
-		if (geometry != NULL &&
-				!intersect_box(geometry, &output->logical_geometry)) {
-			continue;
-		}
+        size_t n_pending = 0;
+        struct grim_output *captured_output = NULL;
+        struct grim_output *output;
+        wl_list_for_each(output, &state.outputs, link) {
+                if (geometry != NULL &&
+                                !intersect_box(geometry, &output->logical_geometry)) {
+                        continue;
+                }
 		if (use_greatest_scale && output->logical_scale > scale) {
 			scale = output->logical_scale;
 		}
@@ -696,15 +697,21 @@ int main(int argc, char *argv[]) {
 			ext_image_copy_capture_session_v1_add_listener(output->ext_image_copy_capture_session,
 				&ext_image_copy_capture_session_listener, output);
 			ext_image_capture_source_v1_destroy(source);
-		} else {
-			output->screencopy_frame = zwlr_screencopy_manager_v1_capture_output(
-				state.screencopy_manager, with_cursor, output->wl_output);
-			zwlr_screencopy_frame_v1_add_listener(output->screencopy_frame,
-				&screencopy_frame_listener, output);
-		}
+                } else {
+                        output->screencopy_frame = zwlr_screencopy_manager_v1_capture_output(
+                                state.screencopy_manager, with_cursor, output->wl_output);
+                        zwlr_screencopy_frame_v1_add_listener(output->screencopy_frame,
+                                &screencopy_frame_listener, output);
+                }
 
-		++n_pending;
-	}
+                if (captured_output == NULL) {
+                        captured_output = output;
+                } else {
+                        captured_output = NULL; // more than one output
+                }
+
+                ++n_pending;
+        }
 
 	if (n_pending == 0) {
 		fprintf(stderr, "supplied geometry did not intersect with any outputs\n");
@@ -725,10 +732,27 @@ int main(int argc, char *argv[]) {
 		get_output_layout_extents(&state, geometry);
 	}
 
-	pixman_image_t *image = render(&state, geometry, scale);
-	if (image == NULL) {
-		return EXIT_FAILURE;
-	}
+        pixman_image_t *image = NULL;
+        bool single_raw = false;
+        if (captured_output != NULL &&
+                        geometry->x == captured_output->logical_geometry.x &&
+                        geometry->y == captured_output->logical_geometry.y &&
+                        geometry->width == captured_output->logical_geometry.width &&
+                        geometry->height == captured_output->logical_geometry.height) {
+                single_raw = true;
+        }
+
+        if (single_raw) {
+                struct grim_buffer *buffer = captured_output->buffer;
+                pixman_format_code_t pixman_fmt = get_pixman_format(buffer->format);
+                image = pixman_image_create_bits(pixman_fmt, buffer->width, buffer->height,
+                        buffer->data, buffer->stride);
+        } else {
+                image = render(&state, geometry, scale);
+        }
+        if (image == NULL) {
+                return EXIT_FAILURE;
+        }
 
 	FILE *file;
 	if (strcmp(output_filename, "-") == 0) {

--- a/render.c
+++ b/render.c
@@ -11,7 +11,7 @@
 
 #include "wlr-screencopy-unstable-v1-protocol.h"
 
-static pixman_format_code_t get_pixman_format(enum wl_shm_format wl_fmt) {
+pixman_format_code_t get_pixman_format(enum wl_shm_format wl_fmt) {
 	switch (wl_fmt) {
 #if GRIM_LITTLE_ENDIAN
 	case WL_SHM_FORMAT_RGB332:


### PR DESCRIPTION
## Summary
- export helper to convert wl_shm format to pixman format
- avoid transformations when capturing a single monitor

## Testing
- `meson setup build` *(fails: wayland-protocols >=1.37 required)*

------
https://chatgpt.com/codex/tasks/task_b_686464b9655883249effe869c6d9e349