### PR TITLE
Fix fractional scaling resize when capturing a single output

### DIFF
--- a/render.c
+++ b/render.c
@@ -8,6 +8,7 @@
 #include "buffer.h"
 #include "output-layout.h"
 #include "render.h"
+#include "box.h"
 
 #include "wlr-screencopy-unstable-v1-protocol.h"
 
@@ -141,20 +142,59 @@ static void compute_composite_region(const struct pixman_f_transform *out2com,
 }
 
 pixman_image_t *render(struct grim_state *state, struct grim_box *geometry,
-		double scale) {
-	int common_width = geometry->width * scale;
-	int common_height = geometry->height * scale;
-	pixman_image_t *common_image = pixman_image_create_bits(PIXMAN_a8r8g8b8,
-		common_width, common_height, NULL, 0);
-	if (!common_image) {
-		fprintf(stderr, "failed to create image with size: %d x %d\n",
-			common_width, common_height);
-		return NULL;
-	}
+                double scale) {
+        struct grim_output *output, *matched_output = NULL;
 
-	struct grim_output *output;
-	wl_list_for_each(output, &state->outputs, link) {
-		struct grim_buffer *buffer = output->buffer;
+        wl_list_for_each(output, &state->outputs, link) {
+                if (output->buffer == NULL) {
+                        continue;
+                }
+
+                if (!intersect_box(&output->logical_geometry, geometry)) {
+                        continue;
+                }
+
+                if (matched_output != NULL) {
+                        matched_output = NULL;
+                        break;
+                }
+                matched_output = output;
+        }
+
+        if (matched_output != NULL &&
+                        geometry->x == matched_output->logical_geometry.x &&
+                        geometry->y == matched_output->logical_geometry.y &&
+                        geometry->width == matched_output->logical_geometry.width &&
+                        geometry->height == matched_output->logical_geometry.height &&
+                        fabs(scale - matched_output->logical_scale) < 0.0001) {
+                struct grim_buffer *buffer = matched_output->buffer;
+                pixman_format_code_t pixman_fmt = get_pixman_format(buffer->format);
+                if (!pixman_fmt) {
+                        fprintf(stderr, "unsupported format %d = 0x%08x\n",
+                                buffer->format, buffer->format);
+                        return NULL;
+                }
+                pixman_image_t *image = pixman_image_create_bits(pixman_fmt,
+                        buffer->width, buffer->height, buffer->data, buffer->stride);
+                if (!image) {
+                        fprintf(stderr, "Failed to create image\n");
+                        return NULL;
+                }
+                return image;
+        }
+
+        int common_width = geometry->width * scale;
+        int common_height = geometry->height * scale;
+        pixman_image_t *common_image = pixman_image_create_bits(PIXMAN_a8r8g8b8,
+                common_width, common_height, NULL, 0);
+        if (!common_image) {
+                fprintf(stderr, "failed to create image with size: %d x %d\n",
+                        common_width, common_height);
+                return NULL;
+        }
+
+       wl_list_for_each(output, &state->outputs, link) {
+               struct grim_buffer *buffer = output->buffer;
 		if (buffer == NULL) {
 			continue;
 		}


### PR DESCRIPTION
## Summary
- avoid transformations when the screenshot covers only a single display

## Testing
- `meson setup build` *(fails: Dependency lookup for wayland-protocols with method 'pkgconfig' failed: Invalid version)*
- `ninja -C build` *(fails: build.ninja not found)*

------
https://chatgpt.com/codex/tasks/task_b_686464b9655883249effe869c6d9e349